### PR TITLE
Remove apply async

### DIFF
--- a/ddtrace/__init__.py
+++ b/ddtrace/__init__.py
@@ -3,7 +3,7 @@ from .pin import Pin
 from .span import Span
 from .tracer import Tracer
 
-__version__ = '0.11.1'
+__version__ = '0.11.1.zapier'
 
 # a global tracer instance
 tracer = Tracer()

--- a/ddtrace/contrib/celery/task.py
+++ b/ddtrace/contrib/celery/task.py
@@ -21,7 +21,8 @@ def patch_task(task, pin=None):
         ('__init__', _task_init),
         ('run', _task_run),
         ('apply', _task_apply),
-        ('apply_async', _task_apply_async),
+        # this causes some weird cls/self confusion in the way we do 1.0 style tasks
+        # ('apply_async', _task_apply_async),
     ]
     for method_name, wrapper in patch_methods:
         # Get original method

--- a/ddtrace/contrib/celery/task.py
+++ b/ddtrace/contrib/celery/task.py
@@ -20,8 +20,8 @@ def patch_task(task, pin=None):
     patch_methods = [
         ('__init__', _task_init),
         ('run', _task_run),
-        ('apply', _task_apply),
-        # this causes some weird cls/self confusion in the way we do 1.0 style tasks
+        # non-run causes some weird cls/self confusion in the way we do 1.0 style tasks
+        # ('apply', _task_apply),
         # ('apply_async', _task_apply_async),
     ]
     for method_name, wrapper in patch_methods:

--- a/ddtrace/contrib/celery/task.py
+++ b/ddtrace/contrib/celery/task.py
@@ -48,8 +48,8 @@ def unpatch_task(task):
     patched_methods = [
         '__init__',
         'run',
-        'apply',
-        'apply_async',
+        # 'apply',
+        # 'apply_async',
     ]
     for method_name in patched_methods:
         # Get wrapped method


### PR DESCRIPTION
Our little hack to deal with apply_async incompatibility with Celery 1.0.

This is for the Datadog support case 134093.

```python
Traceback (most recent call last):
  File "/Users/darko/.virtualenvs/datadog-apm-celery/lib/python2.7/site-packages/celery/app/trace.py", line 374, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/Users/darko/.virtualenvs/datadog-apm-celery/lib/python2.7/site-packages/celery/app/trace.py", line 629, in __protected_call__
    return self.run(*args, **kwargs)
  File "/Users/darko/.virtualenvs/datadog-apm-celery/lib/python2.7/site-packages/ddtrace/contrib/celery/util.py", line 50, in wrapper
    return decorated(pin, wrapped, instance, args, kwargs)
  File "/Users/darko/.virtualenvs/datadog-apm-celery/lib/python2.7/site-packages/ddtrace/contrib/celery/task.py", line 85, in _task_run
    return func(*args, **kwargs)
  File "/Users/darko/Development/datadog-apm-celery/worker.py", line 34, in run
    CeleryClass.apply_async(args=[], kwargs={"stop": True})
TypeError: missing 1 required positional argument
```

And the reproduction scenario https://gist.github.com/apolloFER/fc97831a69830e36ff83309e9f931d2f.